### PR TITLE
Fallback to current directory for webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fastCgi = require('fastcgi-client')
 const defaultOptions = {
   host: '127.0.0.1',
   port: 9000,
-  documentRoot: path.dirname(require.main.filename),
+  documentRoot: path.dirname(require.main.filename || '.'),
   skipCheckServer: true
 }
 


### PR DESCRIPTION
For design reasons, `require.main.filename` is undefined when using webpack. See webpack/webpack#3244. This leads to `TypeError: Path must be a string. Received undefined` in `require('php-fpm')`. Just fall back to the current working directory in that case.