### PR TITLE
Use posix-style path joins, even on Windows machines

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (userOptions = {}, customParams = {}) {
     }
 
     if (!params.script) {
-      params.script = path.join(options.documentRoot, params.document || params.uri)
+      params.script = path.posix.join(options.documentRoot, params.document || params.uri)
     }
 
     const headers = {


### PR DESCRIPTION
We need to explicitly use posix-style paths because the remote php-fpm will only understand posix paths. This fixes requests for with relative paths on Windows machines