### PR TITLE
Don't attempt to fulfill a promise after rejecting it

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function (userOptions = {}, customParams = {}) {
     const php = await fpm
     return new Promise(function (resolve, reject) {
       php.request(headers, function (err, request) {
-        if (err) { reject(err) }
+        if (err) { return reject(err) }
         var output = ''
         var errors = ''
 
@@ -103,7 +103,7 @@ module.exports = function (userOptions = {}, customParams = {}) {
         })
 
         request.stdout.on('end', function () {
-          if (errors) { reject(new Error(errors)) }
+          if (errors) { return reject(new Error(errors)) }
 
           const head = output.match(/^[\s\S]*?\r\n\r\n/)[0]
           const parseHead = head.split('\r\n').filter(_ => _)


### PR DESCRIPTION
On lines [91](https://github.com/ivanslf/node-php-fpm/blob/f8582c166507584ffea3eb317aa3f3585f34dc11/index.js#L91) and [106](https://github.com/ivanslf/node-php-fpm/blob/f8582c166507584ffea3eb317aa3f3585f34dc11/index.js#L106), the promise is rejected, but the code can continue to execute and will attempt to resolve the same promise, which has already been rejected. 