### PR TITLE
Support for multiple response headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,13 +109,26 @@ module.exports = function (userOptions = {}, customParams = {}) {
 
           const head = output.match(/^[\s\S]*?\r\n\r\n/)[0]
           const parseHead = head.split('\r\n').filter(_ => _)
+          let statusCode = 200
+          let statusMessage = ''
+          const responseHeaders = {}
           for (const item of parseHead) {
             const pair = item.split(': ')
-            res.setHeader(pair[0], pair[1])
+
+            if (pair[0] in responseHeaders) {
+              responseHeaders[pair[0]].push(pair[1])
+            } else {
+              responseHeaders[pair[0]] = [ pair[1] ]
+            }
+
             if (pair[0] === 'Status') {
-              res.statusCode = parseInt(pair[1].match(/\d+/)[0])
+              const match = pair[1].match(/(\d+) (.*)/)
+              statusCode = parseInt(match[1])
+              statusMessage = match[2]
             }
           }
+
+          res.writeHead(statusCode, statusMessage, responseHeaders)
           const body = output.slice(head.length)
           res.write(body)
           res.end()


### PR DESCRIPTION
Support for multiple response headers for example, "Cookie:"s or "Vary:"s.
Without this, PHP programs can't respond two or more cookies.